### PR TITLE
Enable RSS feeds

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,8 +3,12 @@ relativeURLs = false
 canonifyURLs = true
 languageCode = 'en-us'
 theme = 'mini'
+[outputs]
+  home = ["HTML", "RSS"]
+  section = ["HTML", "RSS"]
 [params]
-hiddenPostSummaryInHomePage = false 
+hiddenPostSummaryInHomePage = false
+enableRSS = true
 copyright = "© 2024 Henrik Pettersson. All rights reserved."
 showPowerBy = false
 

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,16 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" -}}
+<rss version="2.0">
+  <channel>
+    <title>{{ .Site.Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ .Site.Params.description }}</description>
+    {{ range .Pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</pubDate>
+      <description>{{ .Summary | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/section/notes.rss.xml
+++ b/layouts/section/notes.rss.xml
@@ -1,0 +1,16 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" -}}
+<rss version="2.0">
+  <channel>
+    <title>{{ .Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ .Title }}</description>
+    {{ range .Pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</pubDate>
+      <description>{{ .Summary | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/section/posts.rss.xml
+++ b/layouts/section/posts.rss.xml
@@ -1,0 +1,16 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" -}}
+<rss version="2.0">
+  <channel>
+    <title>{{ .Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ .Title }}</description>
+    {{ range .Pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</pubDate>
+      <description>{{ .Summary | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- generate RSS feeds for home and each section
- add custom feed templates
- expose site RSS link via `enableRSS` param

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a3e400ac8832bb773e96f201ef0e5