### PR TITLE
Fix home RSS feed

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -4,7 +4,7 @@
     <title>{{ .Site.Title }}</title>
     <link>{{ .Permalink }}</link>
     <description>{{ .Site.Params.description }}</description>
-    {{ range .Pages }}
+    {{ range where .Site.RegularPages "Section" "posts" }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
## Summary
- filter the home RSS feed to only include posts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b729b95f0832b80930398695f27ec