### PR TITLE
Rename first blog post to date-based slug

### DIFF
--- a/content/posts/2024-08-04-blog-deployed.md
+++ b/content/posts/2024-08-04-blog-deployed.md
@@ -2,6 +2,8 @@
 title: Blog deployed
 date: 2024-08-04T22:52:22-07:00
 draft: false
+slug: blog-deployed
+aliases: ["/posts/blog-deployed/"]
 image: "images/IMG_2592.jpeg"
 ---
 


### PR DESCRIPTION
## Summary
- revert bulk renames
- rename "Blog deployed" to `2024-08-04-blog-deployed.md`
- add slug and alias for the new filename

## Testing
- `hugo --gc --minify` *(fails: command not found)*
- `apt-get install hugo` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6880e7677634832b9d39a66c81f28ff1