### PR TITLE
Fix RSS link from notes page

### DIFF
--- a/themes/mini/layouts/partials/head.html
+++ b/themes/mini/layouts/partials/head.html
@@ -49,9 +49,7 @@
   {{ partial "math.html" . }}
 {{ end }}
 
-{{ if .OutputFormats.Get "RSS" }}
-  {{ with .OutputFormats.Get "RSS" }}
-    <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
-    <link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
-  {{ end }}
+{{ with .Site.Home.OutputFormats.Get "RSS" }}
+  <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+  <link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
 {{ end }}

--- a/themes/mini/layouts/partials/navigation.html
+++ b/themes/mini/layouts/partials/navigation.html
@@ -10,8 +10,8 @@
 
   <!-- RSS (only if enabled and available) -->
   {{ if .Site.Params.enableRSS }}
-    {{ with .OutputFormats.Get "RSS" }}
-      <a href="{{ .Permalink }}">
+    {{ with .Site.Home.OutputFormats.Get "RSS" }}
+      <a href="{{ .RelPermalink }}">
         {{ with $.Site.Params.subscribe }}{{ . }}{{ else }}{{ i18n "subscribe" }}{{ end }}
       </a>
     {{ end }}


### PR DESCRIPTION
## Summary
- use main feed URL for RSS link in `<head>`
- use main feed URL for RSS link in navigation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688bd8716cf8832ba9ebbd530bb5e933