### PR TITLE
Use responsive grid layout for posts

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -14,6 +14,7 @@ enableRSS = true
 subscribe = "RSS"
 copyright = "© 2024 Henrik Pettersson. All rights reserved."
 showPowerBy = false
+customCSS = ["css/custom.css"]
 
 
 [markup]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 {{ partial "profile.html" . }}
 
-<div id="list-page">
+<div id="list-page" class="posts-grid">
     <!-- 1) Grab all regular pages. -->
     {{ $allPages := .Site.RegularPages }}
 
@@ -69,9 +69,6 @@
       </div>
     </div>
   </section>
-
-  <!-- Divider between posts -->
-  <hr class="post-divider" />
 
   {{ end }}
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,15 @@
+#list-page.posts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
+#list-page.posts-grid .item {
+  margin: 0;
+}
+
+@media (max-width: 600px) {
+  #list-page.posts-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- display posts in a responsive grid
- load custom CSS via Hugo configuration

## Testing
- `npm test` (fails: Error: no test specified)
- `apt-get update` (fails: repository unsigned, unable to install hugo)

------
https://chatgpt.com/codex/tasks/task_e_689b5d377140832b8eef578bf6c3da8d